### PR TITLE
Updates the shortcut keybinding to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Search layer and select it, by matching `textValue`, `name` or `ObjectID`.
 
 ## Usage
 
-Just type <kbd>Alt</kbd>+<kbd>Command</kbd>+<kbd>F</kbd> everywhere.
+Just type <kbd>Alt</kbd>+<kbd>Control</kbd>+<kbd>F</kbd> everywhere.
 
 And enter the textContent/Name/ObjectId that the layers cotain
 

--- a/Sketch Search Everywhere.sketchplugin/Contents/Sketch/manifest.json
+++ b/Sketch Search Everywhere.sketchplugin/Contents/Sketch/manifest.json
@@ -4,7 +4,7 @@
     {
       "script" : "main.js",
       "handler" : "onRun",
-      "shortcut" : "command alt f",
+      "shortcut" : "control alt f",
       "name" : "Search Everywhere",
       "identifier" : "run"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-search-everywhere",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Search layer and select it, by matching `textValue`, `name` or `ObjectID`.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`Command + Alt + F` is bound to `Find and Replace Color...` in Sketch 49.1
I've updated the shortcu to `Control + Alt + F`.